### PR TITLE
⬆️(aws) upgrade terraform syntax to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Upgrade terraform syntax to 0.12
 - Upgrade to Richie 1.6.1
 - Upgrade to Richie 1.5.2
 

--- a/src/aws/cloudfront.tf
+++ b/src/aws/cloudfront.tf
@@ -87,7 +87,7 @@ resource "aws_cloudfront_distribution" "instart_cloudfront_distribution" {
     }
   }
 
-  tags {
+  tags = {
     Environment = "${terraform.workspace}"
   }
 

--- a/src/aws/create_state_bucket/s3.tf
+++ b/src/aws/create_state_bucket/s3.tf
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "state_bucket" {
     }
   }
 
-  tags {
+  tags = {
     Name = "terraform"
   }
 }

--- a/src/aws/s3.tf
+++ b/src/aws/s3.tf
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "instart_static" {
     max_age_seconds = 3600
   }
 
-  tags {
+  tags = {
     Name        = "instart-static"
     Environment = "${terraform.workspace}"
   }
@@ -34,7 +34,7 @@ resource "aws_s3_bucket" "instart_media" {
     enabled = true
   }
 
-  tags {
+  tags = {
     Name        = "instart-media"
     Environment = "${terraform.workspace}"
   }


### PR DESCRIPTION
## Purpose

We use the terraform light docker image so it is not pinned to a version.

While running the terraform playbooks to create S3 buckets for the project, I ran into syntax incompatibility errors due to the new terraform 0.12 release.

# Proposal

I fixed all syntax issues on tags attributes.
