### PR TITLE
🐛(front) load main css from the instart static namespace 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ nosetests.xml
 coverage.xml
 
 # Built statics
-src/backend/instart/static/richie/css/main.css
+src/backend/instart/static/instart/css/main.css
 
 # Site media
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Upgrade terraform syntax to 0.12
 - Upgrade to Richie 1.11.0
 
+### Fixed
+
+- Load main css from the instart static namespace
+
 ### Security
 
 - Upgrade lodash to 4.17.15, and lodash.mergewith to 4.6.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade terraform syntax to 0.12
-- Upgrade to Richie 1.6.1
-- Upgrade to Richie 1.5.2
+- Upgrade to Richie 1.11.0
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY ./src/backend /app/
 COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
 
 # Copy distributed application's statics
-COPY --from=front-builder /builder/src/backend/instart/static/richie /app/src/backend/instart/static/richie
+COPY --from=front-builder /builder/src/backend/instart/static/instart /app/src/backend/instart/static/instart
 
 WORKDIR /app
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,5 +6,5 @@ django-storages==1.6.3
 dockerflow==2019.6.0
 gunicorn==19.9.0
 psycopg2-binary==2.7.7
-richie==1.9.2
+richie==1.11.0
 sentry-sdk==0.9.5

--- a/src/backend/instart/templates/richie/base.html
+++ b/src/backend/instart/templates/richie/base.html
@@ -5,6 +5,10 @@
 <link href="https://fonts.googleapis.com/css?family=Raleway:500,500i,700,900&display=swap" rel="stylesheet">
 {% endblock meta %}
 
+{% block css_links %}
+<link rel="stylesheet" type="text/css" href="{% static 'instart/css/main.css' %}">
+{% endblock css_links %}
+
 {% block body_footer %}
 <div class="body-footer">
     <div class="body-footer-inner">

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -5,18 +5,15 @@
   "scripts": {
     "prettier": "prettier '**/*.+(css|scss)'",
     "prettier-write": "prettier --write '**/*.+(css|scss)'",
-    "sass": "node-sass --include-path node_modules scss/_main.scss ../backend/instart/static/richie/css/main.css",
-    "sass-production": "node-sass --include-path node_modules --output-style compressed scss/_main.scss ../backend/instart/static/richie/css/main.css",
+    "sass": "node-sass --include-path node_modules scss/_main.scss ../backend/instart/static/instart/css/main.css",
+    "sass-production": "node-sass --include-path node_modules --output-style compressed scss/_main.scss ../backend/instart/static/instart/css/main.css",
     "watch-sass": "nodemon -e scss -x 'yarn sass'"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openfun/instart-learning.git"
   },
-  "keywords": [
-    "MOOC",
-    "CMS"
-  ],
+  "keywords": ["MOOC", "CMS"],
   "author": {
     "name": "Open FUN (France Université Numérique)",
     "email": "fun.dev@fun-mooc.fr"
@@ -32,6 +29,6 @@
     "node-sass": "4.11.0",
     "nodemon": "1.18.10",
     "prettier": "1.16.4",
-    "richie-education": "1.9.2"
+    "richie-education": "1.11.0"
   }
 }

--- a/src/frontend/yarn.lock
+++ b/src/frontend/yarn.lock
@@ -2,31 +2,24 @@
 # yarn lockfile v1
 
 
-"@formatjs/intl-relativetimeformat@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.0.0.tgz#019f36491411359f981cfc1ace34931deec0a7e5"
-  integrity sha512-3HF/f8e7uWVU6Qn/EUhC6o8L9yqpFWFLuGPPOB8D8kIlrZhB7ybhapLjAwYtchnr2dVb6JZoeSjI90/qCWpMDg==
+"@formatjs/intl-relativetimeformat@4.2.0", "@formatjs/intl-relativetimeformat@^4.1.1":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.2.0.tgz#dc403699eb5755dd19307c93a6541232b14dd721"
+  integrity sha512-0NQnixfRIdwRMagVR0CmqfKaI8xCtT1oZ0tAU7zrsch0k6N2wJFUYBsOtlgSqRR4hz2gAbVc7Rv5tdzkWW5fgg==
   dependencies:
-    "@formatjs/intl-utils" "^1.1.1"
+    "@formatjs/intl-utils" "^1.4.0"
 
-"@formatjs/intl-relativetimeformat@^3.0.2":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-3.1.0.tgz#a657d67e8e26a5985d72a80699be874c9bc470d3"
-  integrity sha512-xSW9RMJtZZTGAlT7qCom+0INLYgshowpBN0Xf+j4kME+U/g/ogTVRFeGvCZX3nDQ21vdTHAabR3AIGQRX7NU1g==
+"@formatjs/intl-unified-numberformat@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-1.0.1.tgz#5c74d5d1a1e2a9451482da83dfb8524f65603665"
+  integrity sha512-nlHCmisXCzCOloy+My1PCGkjfrkFeHwDSq2IVnt8OFwDbljXX+atGg32T+w3nvRpbMWBJ7GsYIEeaZq+UFMomw==
   dependencies:
-    "@formatjs/intl-utils" "^1.1.0"
+    "@formatjs/intl-utils" "^1.3.0"
 
-"@formatjs/intl-unified-numberformat@^0.4.9":
-  version "0.4.9"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-unified-numberformat/-/intl-unified-numberformat-0.4.9.tgz#343ce36d8c95bd5529ce80120a4abbf933cae69e"
-  integrity sha512-llHvEZTaMEStXK7mFjUMcsS3Qtxd3csdgyo2j/fvjk+NdEBjGYrEO7gdLhGAjh6sDeRGFzMze91ScrwLK3ukqw==
-  dependencies:
-    "@formatjs/intl-utils" "^1.0.1"
-
-"@formatjs/intl-utils@^1.0.1", "@formatjs/intl-utils@^1.1.0", "@formatjs/intl-utils@^1.1.1":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-1.2.0.tgz#a336a882602f37cdd2dbec50163ed8fcf176e35f"
-  integrity sha512-YHvfHRaiKfUxqnNhU9xOweK+iKA4R6uNRdvJeYeY9vENeKOYSAULtrxhLo86wUZHkR2KNqn4Y1xVDzihN3Y28w==
+"@formatjs/intl-utils@^1.3.0", "@formatjs/intl-utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-1.4.0.tgz#b59fdf78bbae9f99c500a298bf73b1945f5991f1"
+  integrity sha512-z5HyJumGzORM+5SpvkAlp/hu0AHDeZcUNKSmj9NjS7kWxOGZMuAdS3X1K5XiE0j5I8r8s8SIaz0IQOdMA1WFeA==
 
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
@@ -1027,38 +1020,33 @@ ini@^1.3.4, ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
 
-intl-format-cache@^4.1.19:
-  version "4.1.19"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.1.19.tgz#43da8f621693dbd770683caacdae049ff3e6f31a"
-  integrity sha512-LIkxfB1KriplBCKsrmWNdmk/fYNFDFkPtmEmPr0zoErypdEsxN9Fpq8VOkIg/JvJk0VMFaDCyjaJ+JRCDqbi2g==
+intl-format-cache@^4.2.1, intl-format-cache@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.2.tgz#4e745d4cda3aa9df2495f0493bed4c6c4ff7093d"
+  integrity sha512-7tY3XadLn8rMHiYVUzH/6NmOe944nJ59LdAWuFm64/m2OfFAEkZTtTHxrEtoxq7HWFddX4aRwDb9P8KB5Z2AvQ==
 
-intl-format-cache@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/intl-format-cache/-/intl-format-cache-4.2.0.tgz#a0dd7bf33c50ea531e242f86f06d4a21e6d69a4f"
-  integrity sha512-OePs43hKTwb7deaPGa6jF8EOIlMdfqrv7t5A9JIFgdFBGjaucuXlh5KXywGvVWjDTzBAU7/XMjkuOgutSOem6Q==
-
-intl-locales-supported@^1.4.5:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.4.7.tgz#24acc88e1337429dbf1926463e6234c1325bbe6d"
-  integrity sha512-3arwVxqTBWRom7NiK9GUB25qLtJToH3QYxqMjbbq/+R3Pz3mMQo4GbWQxgM57Aj0bQnrZipht1fwous+QIPduQ==
-
-intl-messageformat-parser@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-3.1.0.tgz#747e3dbafaf1c1fd07dffa6e4f54ed60e0336ca7"
-  integrity sha512-HUa6oLTy3Q+X0mpmk3g5as8WiM1F2AtssfsmNbFUu4yf+y/eD6aggpbnfjxT4uTJFL9JhcsE2gQfzAF2PTTsFg==
+intl-locales-supported@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/intl-locales-supported/-/intl-locales-supported-1.6.0.tgz#6f66501ef23a58c87f242021cfadb1b012770808"
+  integrity sha512-n8J5v2oBjaOu065/HXeDFU3huv76Ehwj6YovPI7IJ3DCf0EvvwL1lncRj/qobmlyDh0LumwxpU+pVhFR34xjEA==
 
 intl-messageformat-parser@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-3.2.0.tgz#de7ba62cdc8edc80d2b21eb5ada1728b0fdff198"
   integrity sha512-07G+OTgIEsYIPpy793/EU14Slz03nqouODE+CGXlojw1gOF1IaUXk99EOlVdKsPwl95hUJon4dsp9D7/XPBDCw==
 
-intl-messageformat@^7.2.0:
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-7.3.0.tgz#ffc0a01a4afb8756b150278c4a26a5c14b632933"
-  integrity sha512-0oZmhfX6avRhGm4HKvaYIjLMdF8/ziqSX3yS6f/vKVPMAWu1MStoXX8HmA9qdRWVlOwtstFgLu7gXnElFDdV9w==
+intl-messageformat-parser@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-3.2.1.tgz#598795221267cbbd206f1497c42ffced9b5565b6"
+  integrity sha512-ajCL1k1ha0mUrutlBTo5vcTzyfdH2OoghUu8SmR7tJ1D0uifZh9Hqd3ZC2SYVv/GTfTdW//rgKonMgAhZWmwZg==
+
+intl-messageformat@^7.3.1:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-7.3.2.tgz#8dcf53237faec86061ace315f36aeffe7edb4c8d"
+  integrity sha512-1hSgNhnpQqNrr09lFiz/oA3jX+REBuSyXh/ePvSncUicMsREtH3j2X1tDTTFHbK5kHjI+9vcwGpDSZpP8CM/uQ==
   dependencies:
-    intl-format-cache "^4.2.0"
-    intl-messageformat-parser "^3.2.0"
+    intl-format-cache "^4.2.2"
+    intl-messageformat-parser "^3.2.1"
 
 intl-pluralrules@1.0.3:
   version "1.0.3"
@@ -2018,30 +2006,30 @@ react-autowhatever@^10.1.2:
     react-themeable "^1.1.0"
     section-iterator "^2.0.0"
 
-react-dom@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.9.0.tgz#5e65527a5e26f22ae3701131bcccaee9fb0d3962"
-  integrity sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==
+react-dom@16.10.2:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.10.2.tgz#4840bce5409176bc3a1f2bd8cb10b92db452fda6"
+  integrity sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.15.0"
+    scheduler "^0.16.2"
 
-react-intl@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.2.1.tgz#3563d10b4116d61eb3234137f23d71a99d8d68af"
-  integrity sha512-iFxPFsvgGoh94YQbc5H4VDCO7d16c78QXTUfJE4BlKFhuIejL0t+iC5n44529kJCihxGvyJy1HIqPZpIjhprGQ==
+react-intl@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/react-intl/-/react-intl-3.3.2.tgz#e60ba59736b612654653be2409be3b9711a646af"
+  integrity sha512-Y2QMrcVxkVSzuTD/3+wkbJOV+vYcu60KsKY5XqJ6IkzseFY68myk7ijJ1UHXOP/xBdJtwiXVOCG10EDwDGj/xQ==
   dependencies:
-    "@formatjs/intl-relativetimeformat" "^3.0.2"
-    "@formatjs/intl-unified-numberformat" "^0.4.9"
+    "@formatjs/intl-relativetimeformat" "^4.1.1"
+    "@formatjs/intl-unified-numberformat" "^1.0.0"
     "@types/hoist-non-react-statics" "^3.3.1"
     "@types/invariant" "^2.2.30"
     hoist-non-react-statics "^3.3.0"
-    intl-format-cache "^4.1.19"
-    intl-locales-supported "^1.4.5"
-    intl-messageformat "^7.2.0"
-    intl-messageformat-parser "^3.1.0"
+    intl-format-cache "^4.2.1"
+    intl-locales-supported "^1.5.0"
+    intl-messageformat "^7.3.1"
+    intl-messageformat-parser "^3.2.0"
     invariant "^2.1.1"
     shallow-equal "^1.1.0"
 
@@ -2072,10 +2060,10 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+react@16.10.2:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.10.2.tgz#a5ede5cdd5c536f745173c8da47bda64797a4cf0"
+  integrity sha512-MFVIq0DpIhrHFyqLU0S3+4dIcBhhOvBE8bJ/5kHPVOVaGdo0KuiQzpcjCPsf585WvhypqtrMILyoE2th6dT+Lw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -2226,21 +2214,21 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-richie-education@1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.9.2.tgz#aa327a2581ab418d96e57ae62689c81d9299072e"
-  integrity sha512-4f44hcMQrfIrLPP8AobhTQxcZXooJx/ACGS79rphGmaaJpG8E9xQcmxh74+GE/MkH9nPsZsNQFOBoIklEgWgWg==
+richie-education@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/richie-education/-/richie-education-1.11.0.tgz#9cc34a6ba55a1b53232773ea898bb37f276afb5f"
+  integrity sha512-ukAwyRneeivCZoZvEH2KJsMgo/lKG3dXvxi02gK+RSi0P16bdJl2HxWmDmg0024m+ifWbdF1o9MCXtqRbLY0mA==
   dependencies:
-    "@formatjs/intl-relativetimeformat" "4.0.0"
+    "@formatjs/intl-relativetimeformat" "4.2.0"
     bootstrap "4.3.1"
     core-js "3"
     intl-pluralrules "1.0.3"
     lodash-es "4.17.15"
     query-string "6.8.3"
-    react "16.9.0"
+    react "16.10.2"
     react-autosuggest "9.4.3"
-    react-dom "16.9.0"
-    react-intl "3.2.1"
+    react-dom "16.10.2"
+    react-intl "3.3.2"
     react-modal "3.10.1"
 
 rimraf@2, rimraf@^2.6.1:
@@ -2282,10 +2270,10 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
-  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
+scheduler@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.16.2.tgz#f74cd9d33eff6fc554edfb79864868e4819132c1"
+  integrity sha512-BqYVWqwz6s1wZMhjFvLfVR5WXP7ZY32M/wYPo04CcuPM7XZEbV2TBNW7Z0UkguPTl0dWMA59VbNXxK6q+pHItg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## Purpose

`richie<1.11.0` does not allow main styles file override which leads to a `collectstatic` mess with Richie's application styles overriding project styles (they share the same relative static path).

## Proposal

- [x] upgrade to Richie `1.11.0`
- [x] namespace main styles file path by `instart/`
