### PR TITLE
🐳(project) fix sass build in production image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Load main css from the instart static namespace
+- Sass build copy now targets the appropriate path in the production image
 
 ### Security
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ COPY ./src/backend /app/
 COPY ./docker/files/usr/local/bin/entrypoint /usr/local/bin/entrypoint
 
 # Copy distributed application's statics
-COPY --from=front-builder /builder/src/backend/instart/static/instart /app/src/backend/instart/static/instart
+COPY --from=front-builder /builder/src/backend/instart/static/instart /app/instart/static/instart
 
 WORKDIR /app
 


### PR DESCRIPTION
## Purpose

Project's main CSS file is not embedded in the Docker production image and thus cannot be collected.

## Proposal

- [x] fix Sass build copy in the `core` stage