### PR TITLE
:bug: (ckeditor) fix base path to point to CloudFront

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,7 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Build production image
           command: make env.d/aws && make ci-build
@@ -141,9 +139,7 @@ jobs:
       - checkout
       # Generate a version.json file describing app release
       - <<: *generate-version-file
-      # Activate docker-in-docker (with layers caching enabled)
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - setup_remote_docker
       - run:
           name: Build production image
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Load main css from the instart static namespace
 - Sass build copy now targets the appropriate path in the production image
+- Fix CKeditor static files to work with a CDN
 
 ### Security
 

--- a/src/backend/instart/settings.py
+++ b/src/backend/instart/settings.py
@@ -622,6 +622,13 @@ class Production(Base):
     AWS_CLOUDFRONT_DOMAIN = values.Value()
 
     @property
+    def TEXT_CKEDITOR_BASE_PATH(self):
+        """Configure CKEditor with an absolute url as base path to point to CloudFront."""
+        return "//{:s}/static/djangocms_text_ckeditor/ckeditor/".format(
+            self.AWS_CLOUDFRONT_DOMAIN,
+        )
+
+    @property
     def CDN_DOMAIN(self):
         """CDN_DOMAIN is used to load frontend built chunks; it should match the AWS CloudFront
         domain used as a CDN. As other configurations will inherit from this setting, it should


### PR DESCRIPTION
Some of the js/css/lang files downloaded by CKEditor were fetched from the main domain instead of the custom CDN domain. This is fixed by configuring the `TEXT_CKEDITOR_BASE_PATH` setting with an absolute url.