### PR TITLE
🔧(plugins) remove useless override of RICHIE_SECTION_TEMPLATES setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## Changed
+
+- Remove useless override of the `RICHIE_SECTION_TEMPLATES` setting.
+
 ## [1.0.1] - 2019-12-09
 
 ### Changed

--- a/src/backend/instart/settings.py
+++ b/src/backend/instart/settings.py
@@ -172,11 +172,6 @@ class Base(DRFMixin, RichieCoursesConfigurationMixin, Configuration):
         ("richie/single_column.html", _("Single column")),
     )
 
-    RICHIE_SECTION_TEMPLATES = (
-        ("richie/section/section.html", _("Default")),
-        ("richie/section/section_cadenced.html", _("Highlighted items")),
-    )
-
     CMS_PLACEHOLDER_CONF = {
         **RichieCoursesConfigurationMixin.CMS_PLACEHOLDER_CONF,
         # Homepage


### PR DESCRIPTION
## Purpose

This `RICHIE_SECTION_TEMPLATES` setting was overriden with the same values as the default values. 

## Proposal

We want to benefit from the new "unordered list" template for sections so the best is to remove this override and let richie's default apply.
